### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/cartoonify/app/object_detection/dataset_tools/create_oid_tf_record.py
+++ b/cartoonify/app/object_detection/dataset_tools/create_oid_tf_record.py
@@ -42,6 +42,11 @@ import tensorflow as tf
 from app.object_detection.dataset_tools import oid_tfrecord_creation
 from app.object_detection.utils import label_map_util
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 tf.flags.DEFINE_string('input_annotations_csv', None,
                        'Path to CSV containing image bounding box annotations')
 tf.flags.DEFINE_string('input_images_directory', None,

--- a/cartoonify/app/object_detection/dataset_tools/oid_tfrecord_creation.py
+++ b/cartoonify/app/object_detection/dataset_tools/oid_tfrecord_creation.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
+from six import xrange
 
 from app.object_detection.core import standard_fields
 from app.object_detection.utils import dataset_util

--- a/cartoonify/app/object_detection/utils/np_box_list_ops.py
+++ b/cartoonify/app/object_detection/utils/np_box_list_ops.py
@@ -21,6 +21,7 @@ Example box operations that are supported:
 """
 
 import numpy as np
+from six import xrange
 
 from app.object_detection.utils import np_box_list
 from app.object_detection.utils import np_box_ops

--- a/cartoonify/app/object_detection/utils/ops.py
+++ b/cartoonify/app/object_detection/utils/ops.py
@@ -203,9 +203,9 @@ def padded_one_hot_encoding(indices, depth, left_pad):
 
   TODO: add runtime checks for depth and indices.
   """
-  if depth < 0 or not isinstance(depth, (int, long) if six.PY2 else int):
+  if depth < 0 or not isinstance(depth, six.integer_types):
     raise ValueError('`depth` must be a non-negative integer.')
-  if left_pad < 0 or not isinstance(left_pad, (int, long) if six.PY2 else int):
+  if left_pad < 0 or not isinstance(left_pad, six.integer_types):
     raise ValueError('`left_pad` must be a non-negative integer.')
   if depth == 0:
     return None

--- a/cartoonify/app/object_detection/utils/visualization_utils_test.py
+++ b/cartoonify/app/object_detection/utils/visualization_utils_test.py
@@ -20,12 +20,14 @@ https://drive.google.com/a/google.com/file/d/0B5HnKS_hMsNARERpU3MtU3I5RFE/view?u
 
 """
 
+from __future__ import print_function
+
 import os
 
 import numpy as np
+
 import PIL.Image as Image
 import tensorflow as tf
-
 from app.object_detection.utils import visualization_utils
 
 _TESTDATA_PATH = 'object_detection/test_images'
@@ -145,7 +147,7 @@ class VisualizationUtilsTest(tf.test.TestCase):
         for i in range(images_with_boxes_np.shape[0]):
           img_name = 'image_' + str(i) + '.png'
           output_file = os.path.join(self.get_temp_dir(), img_name)
-          print 'Writing output image %d to %s' % (i, output_file)
+          print('Writing output image %d to %s' % (i, output_file))
           image_pil = Image.fromarray(images_with_boxes_np[i, ...])
           image_pil.save(output_file)
 


### PR DESCRIPTION
$ __futurize --stage1 -w .__  # http://python-future.org/futurize_cheatsheet.html

Minimal, safe changes required to make this code syntax compatible with both Python 2 and Python 3. More changes will be required to complete the port to Python 3 but this should provide a solid start in that process without breaking backward compatibility with legacy Python.